### PR TITLE
WebViewScreen: drop no-op override, surface main-frame load errors

### DIFF
--- a/app/src/main/java/im/fdx/v2ex/ui/common/WebViewScreen.kt
+++ b/app/src/main/java/im/fdx/v2ex/ui/common/WebViewScreen.kt
@@ -94,10 +94,6 @@ fun WebViewScreen(
                         
                         // Setup Cookie persistence login logic
                         webViewClient = object : WebViewClient() {
-                            override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-                                return false
-                            }
-
                             override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                                 val cookie = CookieManager.getInstance().getCookie(url)
                                 if (cookie?.contains("A2=") == true && url != null) {
@@ -105,6 +101,20 @@ fun WebViewScreen(
                                     onLoginSuccess()
                                 }
                                 super.onPageStarted(view, url, favicon)
+                            }
+
+                            override fun onReceivedError(
+                                view: WebView?,
+                                request: WebResourceRequest?,
+                                error: WebResourceError?
+                            ) {
+                                super.onReceivedError(view, request, error)
+                                if (request?.isForMainFrame == true) {
+                                    val code = error?.errorCode ?: -1
+                                    val desc = error?.description ?: "unknown"
+                                    Log.w("WebViewScreen", "load error $code: $desc @ ${request.url}")
+                                    title = "加载失败: $desc"
+                                }
                             }
                         }
 


### PR DESCRIPTION
Closes #23.

## Summary

Two small tweaks to the login WebView in `app/src/main/java/im/fdx/v2ex/ui/common/WebViewScreen.kt`.

- Remove the `shouldOverrideUrlLoading` override that just returned false. The default WebViewClient already does that, so the override only adds confusion (it looks like there is allow-list / intent dispatch logic when there isn't).
- Add an `onReceivedError` override (main-frame only) that logs the error and updates the `TopAppBar` title to `加载失败: <description>` so the user can tell a failure apart from a still-loading page.

## Test plan

- [x] Open the login WebView with the device online: cookie persistence + title sync unchanged.
- [x] Open the login WebView in airplane mode: title flips from `正在加载中` to `加载失败: net::ERR_INTERNET_DISCONNECTED` instead of staying blank.
- [x] Subresource failures (favicon, CSS) do not trigger the title change (guarded by `request.isForMainFrame`).